### PR TITLE
fix: env vars type

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
                 return reject(err);
               }
 
-              const hostPart = (useSSL ? 'https://' : 'http://') + `${host}/`
+              const hostPart = (useSSL === 'true' ? 'https://' : 'http://') + `${host}/`
               const filePath = `${bucket}/${path}`;
               file.url = `${hostPart}${filePath}`;
 


### PR DESCRIPTION
According to the configuration, useSSL should be a string. Therefore, we need to compare 2 strings instead of testing for a boolean.